### PR TITLE
version dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "url": "https://github.com/neocities/neocities-node/issues"
   },
   "dependencies": {
-    "form-data": "*"
+    "form-data": "^2.1.4"
   },
   "devDependencies": {
-    "browserify": "*",
-    "uglify-js": "*"
+    "browserify": "^14.3.0",
+    "uglify-js": "^3.0.4"
   },
   "scripts": {
     "browserify": "./node_modules/.bin/browserify ./index.js | ./node_modules/.bin/uglifyjs > neocities.min.js"


### PR DESCRIPTION
Noticed dependencies are not versioned. Things often break unexpectedly with major versions, thought it might  better to lock to minor release semver ranges.