### PR TITLE
docs: remove global flag from install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A node.js library for interacting with the [NeoCities](https://neocities.org/api
 ## Installation
 
 ```
-  $ npm install neocities --global
+$ npm install neocities
 ```
 
 ## Usage


### PR DESCRIPTION
I think the docs are currently incorrect, this isn't a global module.